### PR TITLE
feat: Integrate logo, remove homepage D&D placeholder

### DIFF
--- a/frontend/homepage_styles.css
+++ b/frontend/homepage_styles.css
@@ -58,47 +58,78 @@ a:hover {
     box-shadow: 0 2px 10px rgba(0,0,0,0.2);
 }
 
-#page-footer {
-    border-top: 1px solid var(--glass-border);
-    border-bottom: none;
-    margin-top: 40px;
-    padding: 2em 5%;
-}
-
-#main-header nav {
+#main-header .header-content-wrapper {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    width: 100%;
     max-width: 1200px;
     margin: 0 auto;
 }
 
-#main-header nav span {
-    font-size: 1.8em;
-    font-weight: bold;
-    color: var(--text-primary);
+#main-header .logo-link img#homepageLogo {
+    height: 50px;
+    width: auto;
+    vertical-align: middle;
 }
+
+/* #main-header nav { */ /* Nav is now a direct child of header-content-wrapper */
+    /* No specific styles needed here if ul is flex */
+/* } */
+
+/* #main-header nav span {  */ /* Removed as logo is now an image */
+    /* font-size: 1.8em;
+    font-weight: bold;
+    color: var(--text-primary); */
+/* } */
 
 #main-header nav ul {
     list-style: none;
     padding: 0;
     margin: 0;
     display: flex;
+    align-items: center; /* Vertically align items if they have different heights */
+}
+
+#main-header nav ul li { /* Added to target li for spacing */
+    margin-left: 25px; /* Increased spacing between nav items */
 }
 
 #main-header nav ul li a {
-    margin: 0 15px;
+    /* margin: 0 15px; */ /* Margin now on li */
     color: var(--text-primary);
     font-weight: bold;
     font-size: 1em;
-    padding: 5px 10px;
+    padding: 8px 12px; /* Adjusted padding for better click area */
     border-radius: 4px;
-    transition: background-color 0.3s ease;
+    transition: background-color 0.3s ease, color 0.3s ease;
 }
 #main-header nav ul li a:hover {
     background-color: var(--primary-accent);
     color: var(--text-primary);
     text-decoration: none;
+}
+
+#main-header nav ul li a.button-nav { /* For Sign Up button in nav */
+    background-color: var(--secondary-accent);
+    color: var(--button-text-dark, var(--background-main));
+    padding: 8px 15px;
+    border-radius: 5px;
+    font-weight: bold;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+#main-header nav ul li a.button-nav:hover {
+    background-color: var(--primary-accent);
+    color: var(--text-primary);
+    text-decoration: none;
+}
+
+
+#page-footer {
+    border-top: 1px solid var(--glass-border);
+    border-bottom: none;
+    margin-top: 40px;
+    padding: 2em 5%;
 }
 
 
@@ -210,24 +241,6 @@ main > section {
 .step h3 {
     color: var(--text-primary); /* Ensure heading color */
     margin-bottom: 10px;
-}
-
-/* Drag & Drop Placeholder */
-#homepage-drag-drop-area {
-    padding: 30px;
-    margin-top: 30px;
-    border: 2px dashed var(--primary-accent);
-    border-radius: 10px;
-    text-align: center;
-    background-color: rgba(93, 63, 211, 0.05);
-    cursor: pointer;
-}
-#homepage-drag-drop-area p {
-    color: var(--text-secondary);
-    margin: 5px 0;
-}
-#homepage-drag-drop-area p small {
-    font-size: 0.85em;
 }
 
 
@@ -429,23 +442,23 @@ main > section {
     #hero h1 { font-size: 2.5em; }
     #hero p { font-size: 1.1em; }
 
-    #main-header nav {
+    #main-header nav { /* No longer direct child of main-header for flex */
+        /* flex-direction: column; */ /* This will be on .header-content-wrapper */
+    }
+    /* #main-header nav span { */ /* Logo is an image now */
+        /* margin-bottom: 10px; */
+    /* } */
+    /* Nav items already stack due to .header-content-wrapper: column */
+    /* #main-header nav ul {
         flex-direction: column;
-    }
-    #main-header nav span { /* Logo placeholder */
-        margin-bottom: 10px;
-    }
-    #main-header nav ul {
-        flex-direction: column; /* Stack nav items on smaller screens */
         align-items: center;
-    }
-    #main-header nav ul li {
-        margin-bottom: 8px; /* Space between stacked nav items */
-    }
-    #main-header nav ul li a {
-        margin: 0; /* Reset horizontal margin */
-        /* Further styling for stacked links can be added if needed */
-    }
+    } */
+    /* #main-header nav ul li {
+        margin-bottom: 8px;
+    } */
+    /* #main-header nav ul li a {
+        margin: 0;
+    } */
 
     .steps-container, .pricing-grid {
         flex-direction: column; /* Stack items */
@@ -480,18 +493,38 @@ main > section {
         padding: 12px; /* Ensure buttons are easy to tap */
     }
 
-    #main-header nav a { /* For nav links if they need more specific stacking */
-        display: block;
-        margin: 8px 0;
-        padding: 10px;
-        border-bottom: 1px solid var(--glass-border);
+    #main-header .header-content-wrapper { /* Apply stacking to the wrapper */
+        flex-direction: column;
+        align-items: center;
     }
-    #main-header nav a:last-child {
-        border-bottom: none;
+    #main-header .logo-link img#homepageLogo {
+        height: 40px;
+        margin-bottom: 15px; /* Increased space when stacked */
     }
-     #main-header nav ul { /* Ensure full width for stacked items if needed */
+    #main-header nav { /* Ensure nav takes full width for centered items */
         width: 100%;
     }
+    #main-header nav ul {
+        flex-direction: column;
+        align-items: center;
+        width: 100%;
+    }
+    #main-header nav ul li {
+        margin: 8px 0; /* Vertical margin for stacked items */
+        width: 100%; /* Make li take full width for centered text/button */
+        text-align: center;
+    }
+     #main-header nav ul li a.button-nav { /* Specific for button in nav */
+        display: inline-block; /* Allow padding and auto width */
+        width: auto;
+        padding: 10px 25px; /* Make button more prominent */
+    }
+    /* #main-header nav a:last-child {
+        border-bottom: none;
+    } */
+     /* #main-header nav ul {
+        width: 100%;
+    } */
 
 
     .steps-container {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,12 +7,11 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <header class="glass-container"> <!-- Added class for consistency if styles.css targets it -->
-        <div style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
-            <div class="logo-app"> <!-- new class for app logo styling -->
-                 <h1>Revisume.ai App</h1> <!-- Clarified title -->
-                 <p style="margin:0; font-size: 0.8em;">Your AI-powered resume assistant.</p>
-            </div>
+    <header class="glass-container">
+        <div class="app-header-content-wrapper">
+            <a href="new_homepage.html" class="logo-link-app">
+                <img src="static/logo.png" alt="Revisume.ai Logo" id="appPageLogo">
+            </a>
             <nav>
                 <a href="new_homepage.html" id="homeLinkAppPage">Home</a>
             </nav>

--- a/frontend/new_homepage.html
+++ b/frontend/new_homepage.html
@@ -8,15 +8,20 @@
 </head>
 <body>
     <header id="main-header">
-        <nav>
-            <span>Revisume.ai</span>
-            <ul>
-                <li><a href="#features">Features</a></li>
-                <li><a href="#pricing">Pricing</a></li>
-                <li><a href="#how-it-works">How It Works</a></li>
-                <li><a href="index.html">App</a></li> <!-- Updated text for clarity -->
-            </ul>
-        </nav>
+        <div class="header-content-wrapper">
+            <a href="new_homepage.html" class="logo-link">
+                <img src="static/logo.png" alt="Revisume.ai Logo" id="homepageLogo">
+            </a>
+            <nav>
+                <ul>
+                    <li><a href="#how-it-works">How It Works</a></li>
+                    <li><a href="#features">Features</a></li>
+                    <li><a href="#pricing">Pricing</a></li>
+                    <li><a href="index.html">App</a></li>
+                    <li><a href="#account-creation" class="button-nav">Sign Up</a></li>
+                </ul>
+            </nav>
+        </div>
     </header>
 
     <main>
@@ -49,11 +54,7 @@
                     <p>Receive actionable suggestions and download your improved, job-ready resume in minutes.</p>
                 </div>
             </div>
-            <div id="homepage-drag-drop-area" class="drag-drop-placeholder">
-                <p>Or Drag & Drop Your Resume Here to Get Started</p>
-                <p><small>(PDF, DOCX, TXT files accepted)</small></p>
-            </div>
-            <!-- TODO: Link to actual drag & drop functionality later (or redirect to app page) -->
+            <!-- Placeholder for Drag & Drop area removed as per new requirements -->
         </section>
 
         <section id="features">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -71,39 +71,49 @@ label {
     margin-bottom: 25px;
 }
 
-/* App Page Header */
-header.glass-container { /* Specifically for the app page header */
-    /* background: var(--glass-background); /* Already applied by .glass-container */
-    /* backdrop-filter: blur(12px); /* Slightly more blur for header if desired, or keep consistent */
-    padding: 15px 20px; /* Adjusted padding */
-    max-width: 900px; /* Consistent max-width for app content area */
-    /* text-align: left; /* Ensure header content aligns left if div inside is not full width */
+/* App Page Header Styling - New and Adjustments */
+header.glass-container .app-header-content-wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    /* padding: 0 2%; /* Header already has padding */
+    box-sizing: border-box;
 }
+
+header.glass-container .logo-link-app img#appPageLogo {
+    height: 45px;
+    width: auto;
+    vertical-align: middle;
+}
+
+/* Remove or comment out old .logo-app h1 styles if they exist and are no longer needed */
+/*
 header.glass-container .logo-app h1 {
-    font-size: 1.6em; /* Adjusted for app header */
+    font-size: 1.6em;
     color: var(--text-primary);
-    margin-bottom: 0; /* Removed bottom margin */
+    margin-bottom: 0;
 }
 header.glass-container .logo-app p {
     font-size: 0.85em;
     color: var(--text-secondary);
     margin-top: 2px;
 }
+*/
 
 #homeLinkAppPage {
-    padding: 8px 18px;
+    padding: 8px 15px; /* Consistent padding */
     color: var(--text-primary);
-    background-color: var(--primary-accent);
+    background-color: transparent; /* Remove button-like background to look like a link */
     text-decoration: none;
     font-weight: bold;
     border-radius: 5px;
-    transition: background-color 0.3s ease, transform 0.2s ease;
+    transition: color 0.3s ease; /* Transition color for hover */
 }
 #homeLinkAppPage:hover {
-    background-color: #4B31A5; /* Darker shade of primary accent */
-    text-decoration: none;
-    color: #fff;
-    transform: translateY(-1px);
+    color: var(--secondary-accent);
+    text-decoration: underline; /* Standard link hover */
+    background-color: transparent;
 }
 
 
@@ -296,12 +306,9 @@ main {
     main {
         max-width: 95%;
     }
-    header.glass-container .logo-app h1 {
-        font-size: 1.5em;
-    }
-    header.glass-container .logo-app p {
-        font-size: 0.8em;
-    }
+    /* header.glass-container .logo-app h1 { font-size: 1.5em; } */ /* Old selector */
+    /* header.glass-container .logo-app p { font-size: 0.8em; } */ /* Old selector */
+
     .glass-container h2 {
         font-size: 1.5em;
     }
@@ -331,24 +338,29 @@ main {
         padding: 15px;
     }
     header.glass-container {
-        margin-bottom: 15px; /* Slightly reduced margin */
+        margin-bottom: 15px;
+        padding: 10px 15px; /* Adjusted header padding for mobile */
     }
-    header.glass-container .logo-app h1 {
-        font-size: 1.2em; /* Further adjust app title size */
+    header.glass-container .app-header-content-wrapper {
+        /* flex-direction: column; /* Example: Stack on very small screens if needed */
+        /* align-items: flex-start; */
     }
-    header.glass-container .logo-app p {
-        font-size: 0.7em;
+    header.glass-container .logo-link-app img#appPageLogo {
+        height: 35px;
     }
-    header.glass-container nav { /* For the nav containing homeLinkAppPage */
-        margin-top: 5px;
+    /* header.glass-container .logo-app h1 { font-size: 1.2em; } */ /* Old selector */
+    /* header.glass-container .logo-app p { font-size: 0.7em; } */ /* Old selector */
+
+    header.glass-container nav {
+        /* margin-top: 5px; /* Only if stacked */
     }
     #homeLinkAppPage {
-        padding: 8px 12px;
-        font-size: 0.85em; /* Slightly smaller */
+        padding: 8px 10px; /* Adjust padding */
+        font-size: 0.9em; /* Ensure readability */
     }
 
     .glass-container h2 {
-        font-size: 1.2em; /* Smaller section titles */
+        font-size: 1.2em;
     }
     input[type="file"]::file-selector-button {
         padding: 8px 12px; /* Smaller file button */


### PR DESCRIPTION
This commit includes the following visual updates and cleanups:

1.  **Logo Integration:**
    - Added `frontend/static/logo.png` to the header of the new homepage (`frontend/new_homepage.html`).
    - Added `frontend/static/logo.png` to the header of the existing app page (`frontend/index.html`).
    - Styled the logo appropriately in both `homepage_styles.css` and `styles.css` (app page), including responsive adjustments. Headers were restructured with flexbox wrappers for better layout of logo and navigation.

2.  **Homepage Cleanup:**
    - Removed the placeholder drag & drop area (`div#homepage-drag-drop-area`) from the "How It Works" section of `new_homepage.html`.
    - Removed associated CSS for the deleted drag & drop placeholder from `homepage_styles.css`.

Note: The feature icons you mentioned (JPGs for 'How It Works' and 'Features' sections) were not found in `frontend/static/` and thus could not be integrated in this commit.