### PR TITLE
feat: Add icons to homepage sections

### DIFF
--- a/frontend/new_homepage.html
+++ b/frontend/new_homepage.html
@@ -39,17 +39,17 @@
             <h2>How Revisume.ai Works</h2>
             <div class="steps-container">
                 <div class="step">
-                    <div class="step-icon">[Icon: Upload]</div>
+                    <div class="step-icon"><img src="static/icon_upload.jpg" alt="Upload resume icon" class="step-icon-img"></div>
                     <h3>1. Upload or Paste</h3>
                     <p>Easily upload your current resume (PDF, DOCX, TXT) or simply paste the text.</p>
                 </div>
                 <div class="step">
-                    <div class="step-icon">[Icon: AI Brain]</div>
+                    <div class="step-icon"><img src="static/icon_brain.jpg" alt="AI brain icon" class="step-icon-img"></div>
                     <h3>2. AI Enhances</h3>
                     <p>Our intelligent platform analyzes your resume for keywords, clarity, ATS compatibility, and more.</p>
                 </div>
                 <div class="step">
-                    <div class="step-icon">[Icon: Download]</div>
+                    <div class="step-icon"><img src="static/icon_download.jpg" alt="Download resume icon" class="step-icon-img"></div>
                     <h3>3. Get Optimized Resume</h3>
                     <p>Receive actionable suggestions and download your improved, job-ready resume in minutes.</p>
                 </div>
@@ -61,33 +61,33 @@
             <h2>Core Features & Benefits</h2>
             <div class="features-grid">
                 <div class="feature-item">
-                    <div class="feature-icon">[Icon: Target]</div>
+                    <div class="feature-icon"><img src="static/icon_smart suggestions.jpg" alt="Smart suggestions icon" class="feature-icon-img"></div>
                     <h4>Smart Resume Optimization</h4>
                     <p>AI-driven analysis identifies areas for improvement, suggests powerful action verbs, and ensures your resume is tailored for Applicant Tracking Systems (ATS).</p>
                 </div>
                 <div class="feature-item">
-                    <div class="feature-icon">[Icon: Magnify]</div>
+                    <div class="feature-icon"><img src="static/icon_job matching ai.jpg" alt="Job matching AI icon" class="feature-icon-img"></div>
                     <h4>Job Matching AI</h4>
                     <p>Upload a job description and let our AI highlight key skills and keywords, helping you customize your resume for specific roles and increase your match rate.</p>
                 </div>
                 <div class="feature-item">
-                    <div class="feature-icon">[Icon: Globe]</div>
+                    <div class="feature-icon"><img src="static/icon_ai powered translation.jpg" alt="AI powered translation icon" class="feature-icon-img"></div>
                     <h4>AI-Powered Translation</h4>
                     <p>Break language barriers. Translate your resume into multiple languages to apply for international job opportunities seamlessly.</p>
                 </div>
                 <div class="feature-item">
-                    <div class="feature-icon">[Icon: Chart Up]</div>
+                    <div class="feature-icon"><img src="static/icon_chart up.jpg" alt="Chart up icon" class="feature-icon-img"></div>
                     <h4>Success Stories & Insights</h4>
                     <p>Join thousands of users who've landed their dream jobs. Gain insights into what makes a resume successful in today's competitive market.</p>
                     <!-- Placeholder for actual stories/testimonials -->
                 </div>
                  <div class="feature-item">
-                    <div class="feature-icon">[Icon: Shield]</div>
+                    <div class="feature-icon"><img src="static/icon_ats compatibility check.jpg" alt="ATS compatibility check icon" class="feature-icon-img"></div>
                     <h4>ATS Compatibility Check</h4>
                     <p>Get detailed feedback on how well your resume will parse through common Applicant Tracking Systems, ensuring it reaches human eyes.</p>
                 </div>
                 <div class="feature-item">
-                    <div class="feature-icon">[Icon: Lightbulb]</div>
+                    <div class="feature-icon"><img src="static/icon_smart suggestions.jpg" alt="Smart suggestions icon" class="feature-icon-img"></div>
                     <h4>Smart Suggestions (AI Jules)</h4>
                     <p>Receive contextual advice on phrasing, impact, and professional tone from our advanced AI assistant, "AI Jules".</p>
                 </div>


### PR DESCRIPTION
I've replaced text placeholders in the "How Revisume.ai Works" and "Core Features & Benefits" sections of your new homepage (`frontend/new_homepage.html`) with corresponding JPG image icons from the `frontend/static/` directory.

The following icons were added:
- How It Works:
    - Upload: `static/icon_upload.jpg`
    - AI Enhances: `static/icon_brain.jpg`
    - Get Optimized Resume: `static/icon_download.jpg`
- Core Features & Benefits:
    - Smart Resume Optimization: `static/icon_smart suggestions.jpg`
    - Job Matching AI: `static/icon_job matching ai.jpg`
    - AI-Powered Translation: `static/icon_ai powered translation.jpg`
    - Success Stories & Insights: `static/icon_chart up.jpg`
    - ATS Compatibility Check: `static/icon_ats compatibility check.jpg`
    - Smart Suggestions (AI Jules): `static/icon_smart suggestions.jpg`

All new image tags include appropriate alt text for accessibility and a class for potential future styling (`step-icon-img` or `feature-icon-img`).