### PR TITLE
style: Adjust icon and logo sizes for improved visibility

### DIFF
--- a/frontend/homepage_styles.css
+++ b/frontend/homepage_styles.css
@@ -68,7 +68,7 @@ a:hover {
 }
 
 #main-header .logo-link img#homepageLogo {
-    height: 50px;
+    height: 70px;
     width: auto;
     vertical-align: middle;
 }
@@ -243,6 +243,13 @@ main > section {
     margin-bottom: 10px;
 }
 
+.step-icon img.step-icon-img {
+    max-width: 45px; /* Or a value that matches previous placeholder size */
+    height: auto;
+    display: block; /* Or inline-block if preferred */
+    margin: 0 auto 15px auto; /* Center if block, adjust margin-bottom */
+}
+
 
 /* Features & Benefits Section */
 .features-grid {
@@ -264,6 +271,13 @@ main > section {
 .feature-item h4 {
     color: var(--text-primary);
     margin-bottom: 8px;
+}
+
+.feature-icon img.feature-icon-img {
+    max-width: 55px; /* Or a value that matches previous placeholder size */
+    height: auto;
+    display: block; /* Or inline-block if preferred */
+    margin: 0 auto 10px auto; /* Center if block, adjust margin-bottom */
 }
 
 /* Pricing Plans Section */

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -82,7 +82,7 @@ header.glass-container .app-header-content-wrapper {
 }
 
 header.glass-container .logo-link-app img#appPageLogo {
-    height: 45px;
+    height: 60px;
     width: auto;
     vertical-align: middle;
 }
@@ -346,7 +346,7 @@ main {
         /* align-items: flex-start; */
     }
     header.glass-container .logo-link-app img#appPageLogo {
-        height: 35px;
+        height: 45px;
     }
     /* header.glass-container .logo-app h1 { font-size: 1.2em; } */ /* Old selector */
     /* header.glass-container .logo-app p { font-size: 0.7em; } */ /* Old selector */


### PR DESCRIPTION
This commit addresses feedback regarding the display size of icons and logos:

- Homepage (`new_homepage.html` via `homepage_styles.css`):
    - Scaled down icons in "How It Works" and "Core Features & Benefits" sections to be more appropriately sized (around 45px and 55px max-width respectively).
    - Increased the height of the main homepage logo (`#homepageLogo`) from 50px to 70px for better prominence.
- App Page (`index.html` via `styles.css`):
    - Increased the height of the app page logo (`#appPageLogo`) from 45px to 60px (and from 35px to 45px on screens <480px wide).

These changes ensure the icons are not overly large and that the branding (logo) is more clearly visible across the site.