### PR TITLE
fix: Correct indentation for except blocks in analyze_resume

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2178,11 +2178,11 @@ def analyze_resume():
         }), 200
 
     except ApiException as e:
-            logger.error(f"Watson NLU API error during analysis of '{filename}': {e.code} - {e.message}")
-            return jsonify({"error": f"Watson NLU API error: {e.message}"}), 500
-        except Exception as e:
-            logger.error(f"Unexpected error during Watson NLU analysis of '{filename}': {e}")
-            return jsonify({"error": "Analysis failed due to an unexpected server error."}), 500
+        logger.error(f"Watson NLU API error during analysis of '{filename}': {e.code} - {e.message}")
+        return jsonify({"error": f"Watson NLU API error: {e.message}"}), 500
+    except Exception as e:
+        logger.error(f"Unexpected error during Watson NLU analysis of '{filename}': {e}")
+        return jsonify({"error": "Analysis failed due to an unexpected server error."}), 500
 
     logger.error("File object was not valid in /analyze_resume for an unknown reason (should have been caught earlier).")
     return jsonify({"error": "An unexpected error occurred with the file processing."}), 500


### PR DESCRIPTION
I've corrected an IndentationError in `backend/app.py` within the `analyze_resume` function. The `except ApiException as e:` and `except Exception as e:` clauses (and their contained code) were not correctly aligned with the `try` statement after a previous indentation fix.

This commit ensures that:
- The `try` keyword is at a 4-space indent.
- Code within the `try` block is at an 8-space indent.
- The `except` keywords are aligned with `try` at a 4-space indent.
- Code within each `except` block is at an 8-space indent.

This resolves the `IndentationError: unindent does not match any outer indentation level` previously reported at line 2183.