### PR TITLE
feat: Implement Phase 1 of visual refresh for homepage and app page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,12 +8,13 @@
 </head>
 <body>
     <header class="glass-container">
-        <div class="app-header-content-wrapper">
-            <a href="new_homepage.html" class="logo-link-app">
-                <img src="static/logo.png" alt="Revisume.ai Logo" id="appPageLogo">
-            </a>
-            <nav>
+        <div class="app-header-content-wrapper" style="display: flex; justify-content: center; align-items: center; position: relative;">
+            <div class="logo-container-app" style="text-align: center; flex-grow: 1;"> <!-- New container for logo -->
+                <img src="/static/revisume.jpg" alt="Revisume Logo" id="appPageLogoNew" class="app-logo-stylized" style="display: inline-block; max-height: 60px;"> <!-- Apply some default styling for now -->
+            </div>
+            <nav style="position: absolute; right: 20px; top: 50%; transform: translateY(-50%);"> <!-- Example styling for nav -->
                 <a href="new_homepage.html" id="homeLinkAppPage">Home</a>
+                <!-- Account button will be added here later -->
             </nav>
         </div>
     </header>
@@ -33,12 +34,12 @@
             <h2>Upload Your Resume</h2>
             <!-- Updated accept attribute to include .txt -->
             <input type="file" id="resumeUpload" accept=".pdf,.doc,.docx,.txt">
-            <button id="analyzeButton">Optimize Resume</button> <!-- Changed from onclick to id for event listener -->
+            <button id="analyzeButton" class="button-primary-app">Optimize Resume</button> <!-- Changed from onclick to id for event listener -->
 
             <div class="input-group text-input-group" style="margin-top: 20px;">
                 <label for="resumeTextInput" style="display:block; margin-bottom:8px; font-weight: bold;">Or Paste Resume Text Here:</label>
                 <textarea id="resumeTextInput" rows="10" placeholder="Paste your resume text here..." style="width: 100%; padding: 10px; border-radius: 5px; border: 1px solid #ccc; font-family: inherit;"></textarea>
-                <button id="analyzeTextButton" class="button" style="margin-top: 10px;">Analyze Pasted Text</button>
+                <button id="analyzeTextButton" class="button button-primary-app" style="margin-top: 10px;">Analyze Pasted Text</button>
             </div>
         </section>
         
@@ -46,20 +47,20 @@
             <h2>AI Analysis</h2>
             <div id="results-display" class="results-box">Upload a resume to see AI-powered enhancements.</div>
 
-            <button id="checkAtsButton">Check ATS Compatibility</button>
+            <button id="checkAtsButton" class="button-primary-app">Check ATS Compatibility</button>
             <div id="atsSuggestionsDisplay" class="results-box">Click the button to check ATS compatibility.</div>
 
-            <button id="getSmartSuggestionsButton">Get Smart Suggestions (AI Jules)</button>
+            <button id="getSmartSuggestionsButton" class="button-primary-app">Get Smart Suggestions (AI Jules)</button>
             <div id="smartSuggestionsDisplay" class="results-box">Click the button for AI-powered smart suggestions.</div>
 
-            <button id="getJobMarketInsightsButton">Get Job Market Insights (AI Jules)</button>
+            <button id="getJobMarketInsightsButton" class="button-primary-app">Get Job Market Insights (AI Jules)</button>
             <div id="jobMarketInsightsDisplay" class="results-box">Click the button for AI-powered job market insights.</div>
         </section>
 
         <section id="job-match-section" class="glass-container">
             <h2>Job Description Match</h2>
             <textarea id="jobDescriptionInput" rows="10" placeholder="Paste the job description here..."></textarea>
-            <button id="jobMatchButton">Analyze Job Match</button>
+            <button id="jobMatchButton" class="button-primary-app">Analyze Job Match</button>
             <div id="jobMatchResultsDisplay" class="results-box">Enter a job description to see match analysis.</div>
         </section>
 
@@ -76,7 +77,7 @@
                     <!-- Add more languages as needed -->
                 </select>
             </div>
-            <button id="translateResumeButton">Translate Resume</button>
+            <button id="translateResumeButton" class="button-primary-app">Translate Resume</button>
             <div id="translatedResumeDisplay" class="results-box">
                 Translated resume will appear here.
             </div>

--- a/frontend/new_homepage.html
+++ b/frontend/new_homepage.html
@@ -10,7 +10,7 @@
     <header id="main-header">
         <div class="header-content-wrapper">
             <a href="new_homepage.html" class="logo-link">
-                <img src="/static/logo.png" alt="Revisume.ai Logo" id="homepageLogo">
+                <img src="/static/revisume.jpg" alt="Revisume Logo" id="homepageRevisumeImage" style="max-height: 60px;">
             </a>
             <nav>
                 <ul>
@@ -36,7 +36,10 @@
         </section>
 
         <section id="how-it-works">
-            <h2>How Revisume.ai Works</h2>
+            <div style="text-align: center; margin-bottom: 20px;">
+                <img src="/static/revisume.jpg" alt="Revisume" style="display: block; margin-left: auto; margin-right: auto; margin-bottom: 10px; max-height: 70px;">
+                <p style="font-size: 1.8em; font-weight: 600; color: var(--text-primary);">From Upload to Opportunity—Here’s How</p>
+            </div>
             <div class="steps-container">
                 <div class="step">
                     <div class="step-icon"><img src="/static/icon_upload.jpg" alt="Upload resume icon" class="step-icon-img"></div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,5 +1,6 @@
 /* APP PAGE STYLES (styles.css) */
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Sora:wght@400;600;700&display=swap');
 
 :root {
     --primary-accent: #5D3FD3; /* Deep futuristic purple */
@@ -9,7 +10,7 @@
     --text-secondary: #B1B1B1; /* Light gray */
     --success-confirm: #21D19F; /* Neon teal */
     --error-alert: #D32145; /* Deep red */
-    --glass-background: rgba(40, 40, 70, 0.25); /* Darker, slightly more opaque glass for app */
+    --glass-background: rgba(40, 40, 70, 0.3); /* Darker, slightly more opaque glass for app */
     --glass-border: rgba(255, 255, 255, 0.15); /* Brighter border for contrast */
     --input-background: rgba(255, 255, 255, 0.08);
     --button-text-dark: #1A1A2E; /* For light buttons like secondary-accent */
@@ -27,7 +28,7 @@ html, body {
 }
 
 body {
-    font-family: 'Roboto', sans-serif;
+    font-family: 'Inter', sans-serif;
     background-color: var(--background-main);
     /* Optional: Add subtle gradient if desired, but solid dark often works well for apps */
     /* background: linear-gradient(to bottom right, var(--background-main), #2a2a3e); */
@@ -45,10 +46,10 @@ h1, h2, h3, h4, h5, h6 {
     margin-bottom: 0.5em; /* Consistent bottom margin */
 }
 h1 { font-size: 2em; }
-h2 { font-size: 1.7em; } /* Existing .glass-container h2 */
-h3 { font-size: 1.4em; } /* Existing .results-box h3 / general h3 */
-h4 { font-size: 1.2em; } /* Existing .results-box h4 */
-h5 { font-size: 1.0em; } /* Existing .results-box h5 */
+h2 { font-size: 1.7em; } /* Existing .glass-container h2 / general h2 */
+h3 { font-size: 1.5em; font-weight: 600; } /* Existing .results-box h3 / general h3 */
+h4 { font-size: 1.2em; } /* Existing .results-box h4 / general h4 */
+h5 { font-size: 1.0em; } /* Existing .results-box h5 / general h5 */
 
 p, label { /* Apply to labels as well */
     color: var(--text-secondary);
@@ -126,9 +127,11 @@ main {
 }
 
 .glass-container h2 { /* Section titles */
-    font-size: 1.7em;
-    color: var(--text-primary); /* Brighter for titles */
-    margin-bottom: 20px;
+    font-family: 'Sora', sans-serif;
+    font-size: 2.0em; /* Increased from 1.7em, slightly less than homepage's 2.2em for internal page hierarchy */
+    font-weight: 600; /* Added for consistency */
+    color: var(--text-primary);
+    margin-bottom: 25px; /* Increased from 20px */
     text-align: center;
 }
 
@@ -167,21 +170,25 @@ main {
 
 /* General Button Styling (inside .glass-container) */
 .glass-container button {
-    background-color: var(--primary-accent); /* Primary buttons use primary accent */
+    background-color: var(--secondary-accent); /* Default to secondary like homepage */
     color: var(--text-primary);
     padding: 12px 25px;
     border: none;
-    border-radius: 8px;
-    font-size: 1.05em;
+    border-radius: 5px; /* Match homepage */
+    font-size: 1.1em; /* Match homepage */
     cursor: pointer;
-    transition: background-color 0.3s ease, transform 0.2s ease;
-    display: block;
-    margin: 20px auto 10px auto; /* Adjusted margin */
+    text-transform: uppercase; /* Match homepage */
     font-weight: bold;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2); /* Added from homepage for consistency */
+    display: block; /* Keep as block for app layout or make inline-block if needed */
+    margin: 20px auto 10px auto;
 }
 .glass-container button:hover {
-    background-color: #4B31A5; /* Darker shade of primary */
+    background-color: #FFAC47; /* Matches homepage default button hover */
     transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.3); /* Matches homepage */
+    /* color: var(--text-primary); Ensure text color remains if needed */
 }
 .glass-container button:active {
     transform: translateY(0);
@@ -195,6 +202,16 @@ main {
 }
 #subscribeButton:hover {
     background-color: #1AA882; /* Darker teal */
+}
+
+.glass-container button.button-primary-app {
+    background-color: var(--primary-accent);
+    color: var(--text-primary); /* Ensure text color if not inherited */
+}
+
+.glass-container button.button-primary-app:hover {
+    background-color: #7658D1; /* Matches homepage primary button hover */
+    color: var(--text-primary); /* Ensure text color */
 }
 
 


### PR DESCRIPTION
This commit includes the following changes as part of the initial visual refresh:

Homepage (`frontend/new_homepage.html`):
- Header logo updated to use `revisume.jpg`. (Verified already updated)
- "How it Works" section heading updated to "From Upload to Opportunity—Here’s How" and incorporates `revisume.jpg`. (Verified already updated)

App Page (`frontend/index.html` and `frontend/styles.css`):
- Header logo updated to use `revisume.jpg`, centered, and nav adjusted.
- Fonts updated: `body` uses 'Inter', section titles (`h2`) use 'Sora' with increased size/weight. `h3` size/weight adjusted.
- Basic styling alignment in `styles.css`:
    - `--glass-background` opacity matched to homepage.
    - General button styles aligned with homepage (default to secondary accent, uppercase, border-radius, font-size).
    - New `.button-primary-app` class created and applied to relevant buttons in `index.html` for primary (purple) styling.