### PR TITLE
fix: Update SSO button colors for improved contrast

### DIFF
--- a/backend/test_app.py
+++ b/backend/test_app.py
@@ -441,11 +441,11 @@ if __name__ == '__main__':
 
 # Test Name: test_sso_button_styles_on_homepage
 # Description: Verify that the Single Sign-On (SSO) buttons on new_homepage.html (or where they are implemented)
-#              have the new styles (blue background, white text).
+#              have the updated dark styles.
 # How to test: Manually run the app, navigate to the page with SSO buttons (likely new_homepage.html or login/register pages).
 #              Use browser developer tools to inspect the CSS applied to `.sso-options .button`.
-# Expected: `background-color` should be `rgb(0, 123, 255)` (from `var(--primary-accent)`) and `color` should be `rgb(255, 255, 255)` (white).
-#           Hover styles should also match the darker blue background and border.
+# Expected: `background-color` should be `#2C3E50` (Dark Slate Gray), and `color` should be `#FFFFFF` (White).
+#           Hover styles should show `background-color: #1A252F` (Darker Slate Gray).
 
 # Test Name: test_edit_account_page_content_display
 # Description: Verify that the content on the /account/edit page (edit_account.html) correctly displays current_user's information.

--- a/frontend/homepage_styles.css
+++ b/frontend/homepage_styles.css
@@ -442,9 +442,9 @@ main > section {
 }
 .sso-options .button {
     margin: 6px;
-    background-color: var(--primary-accent); /* New: Tech Blue */
-    color: #FFFFFF; /* New: White text for strong contrast */
-    border: 1px solid var(--primary-accent); /* New: Tech Blue border */
+    background-color: #2C3E50; /* New: Dark Slate Gray */
+    color: #FFFFFF; /* White text for strong contrast */
+    border: 1px solid #2C3E50; /* New: Matching Dark Slate Gray border */
     padding: 8px 18px;
     display: inline-flex;
     align-items: center;
@@ -452,9 +452,9 @@ main > section {
     transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }
 .sso-options .button:hover {
-    background-color: #0056b3; /* Darker blue for hover */
+    background-color: #1A252F; /* Darker Slate Gray for hover */
     color: #FFFFFF;
-    border-color: #004085; /* Darker blue border for hover */
+    border-color: #1A252F; /* Matching darker border for hover */
     text-decoration: none;
 }
 


### PR DESCRIPTION
Based on your feedback, this commit updates the styles for the Single Sign-On (SSO) buttons on the homepage.

The background color of the Google and LinkedIn sign-in buttons has been changed to a dark slate gray (#2C3E50), with a darker shade (#1A252F) on hover. The text color remains white (#FFFFFF) to ensure high contrast and readability against the new darker background. The border color now matches the background color.

This change improves the visual appeal and accessibility of the SSO buttons. Conceptual tests in backend/test_app.py have been updated to reflect these new color choices.