### PR TITLE
Fix: Resolve import and NameErrors for Render deployment

### DIFF
--- a/backend/extensions.py
+++ b/backend/extensions.py
@@ -1,7 +1,9 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_bcrypt import Bcrypt
+from flask_migrate import Migrate
 
 db = SQLAlchemy()
 login_manager = LoginManager()
 bcrypt = Bcrypt()
+migrate = Migrate()


### PR DESCRIPTION
- Add Flask-Migrate to backend/extensions.py.
- Correct Blueprint import for cover_letter_app in backend/app.py.
- Move login_manager configuration into the try/except block in backend/app.py to prevent NameError if extension import fails.
- Ensure extensions are set to None in except blocks if initialization fails.