### PR TITLE
Fix: Use absolute paths for blueprint template and static folders

### DIFF
--- a/backend/cover_letter_app/__init__.py
+++ b/backend/cover_letter_app/__init__.py
@@ -1,4 +1,10 @@
+import os # Added for path manipulation
 from flask import Blueprint
+
+# Define paths relative to this file's location (backend/cover_letter_app/__init__.py)
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+TEMPLATE_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'templates', 'cover_letter')
+STATIC_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'static')
 
 # Templates are in frontend/templates/cover_letter
 # Static folder can remain general if not specifically used by this blueprint,
@@ -6,8 +12,8 @@ from flask import Blueprint
 cover_letter_bp = Blueprint(
     'cover_letter',
     __name__,
-    template_folder='../../frontend/templates/cover_letter', # Corrected path
-    static_folder='../../frontend/static' # General static folder, adjust if needed
+    template_folder=TEMPLATE_FOLDER, # Corrected path
+    static_folder=STATIC_FOLDER # General static folder, adjust if needed
 )
 
 # Import routes after blueprint definition to avoid circular imports

--- a/backend/mock_interview_app/__init__.py
+++ b/backend/mock_interview_app/__init__.py
@@ -1,5 +1,14 @@
+import os # Added for path manipulation
 from flask import Blueprint
 
-mock_interview_bp = Blueprint('mock_interview', __name__, template_folder='../../frontend/templates/mock_interview', static_folder='../../frontend/static')
+# Define paths relative to this file's location (backend/mock_interview_app/__init__.py)
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+TEMPLATE_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'templates', 'mock_interview')
+STATIC_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'static')
+
+mock_interview_bp = Blueprint('mock_interview',
+                              __name__,
+                              template_folder=TEMPLATE_FOLDER,
+                              static_folder=STATIC_FOLDER)
 
 from . import routes

--- a/backend/resume_builder/__init__.py
+++ b/backend/resume_builder/__init__.py
@@ -1,11 +1,20 @@
+import os # Added for path manipulation
 from flask import Blueprint
+
+# Define paths relative to this file's location (backend/resume_builder/__init__.py)
+# os.path.dirname(__file__) is backend/resume_builder/
+# os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')) is project_root/ (e.g., src/)
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+TEMPLATE_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'templates', 'resume_builder')
+STATIC_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'static')
+
 
 # Define the blueprint. Adjust template_folder if necessary.
 # Assuming resume_builder templates are in 'frontend/templates/resume_builder/'
 bp = Blueprint('resume_builder',
                __name__,
-               template_folder='../../frontend/templates/resume_builder',
-               static_folder='../../frontend/static', # If it has specific static files
+               template_folder=TEMPLATE_FOLDER,
+               static_folder=STATIC_FOLDER, # If it has specific static files
                static_url_path='/resume-builder/static') # URL path for its static files
 
 from . import routes  # Import routes to register them with the blueprint

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1,4 +1,5 @@
 import logging # Added for logging
+import os # Added for path manipulation
 from flask import Blueprint, render_template, redirect, url_for, flash, request, jsonify
 from flask_login import login_required, current_user, login_user, logout_user
 from backend.models import User, Resume, CoverLetter, MockInterview, Credit, FeatureUsageLog
@@ -9,7 +10,13 @@ from backend.forms import LoginForm, RegistrationForm # Added for auth forms
 # Configure logger for this blueprint
 logger = logging.getLogger(__name__) # Added for logging
 
-main_bp = Blueprint('main', __name__, template_folder='../../frontend/templates')
+# Define paths relative to this file's location (backend/routes.py)
+# os.path.dirname(__file__) is backend/
+# os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) is project_root/ (e.g., src/)
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+MAIN_TEMPLATE_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'templates')
+
+main_bp = Blueprint('main', __name__, template_folder=MAIN_TEMPLATE_FOLDER)
 
 @main_bp.route('/')
 def home():


### PR DESCRIPTION
- Modified blueprint definitions in backend/routes.py, backend/resume_builder/__init__.py, backend/cover_letter_app/__init__.py, and backend/mock_interview_app/__init__.py.
- Template and static folder paths are now calculated as absolute paths from the project root to prevent TemplateNotFound errors due to relative path resolution issues.