### PR TITLE
Fix: Update spaCy to non-yanked version 3.7.5

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ Flask-SQLAlchemy==3.1.1
 Flask-Migrate==4.0.7
 alembic==1.13.2
 python-docx==1.1.2
-spacy==3.7.6
+spacy==3.7.5
 textblob==0.18.0.post0
 gunicorn==22.0.0
 psycopg2-binary==2.9.9 # For PostgreSQL, optional for SQLite


### PR DESCRIPTION
Changed spacy==3.7.6 to spacy==3.7.5 in backend/requirements.txt to resolve deployment warning about using a yanked package version.