### PR TITLE
Fix: Resolve blank pages by centralizing template configuration

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -24,17 +24,19 @@ logger.info("Environment variables loaded.")
 
 # --- App Initialization and Configuration ---
 # This assumes app.py is in backend/ and we want to go one level up to src/ (project_root)
-# and then to frontend/static
-PROJECT_ROOT_FOR_STATIC_CONFIG = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-FLASK_STATIC_FOLDER_PATH = os.path.join(PROJECT_ROOT_FOR_STATIC_CONFIG, 'frontend', 'static')
+# and then to frontend/static and frontend/templates
+PROJECT_ROOT_FOR_APP_CONFIG = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+FLASK_STATIC_FOLDER_PATH = os.path.join(PROJECT_ROOT_FOR_APP_CONFIG, 'frontend', 'static')
+FLASK_APP_TEMPLATE_FOLDER_PATH = os.path.join(PROJECT_ROOT_FOR_APP_CONFIG, 'frontend', 'templates')
 
 app = Flask(
     __name__,
     instance_relative_config=True,
     static_folder=FLASK_STATIC_FOLDER_PATH,
-    static_url_path='/static'
+    static_url_path='/static',
+    template_folder=FLASK_APP_TEMPLATE_FOLDER_PATH
 )
-logger.info(f"Flask app initialized. Static folder: {FLASK_STATIC_FOLDER_PATH}, Static URL path: /static")
+logger.info(f"Flask app initialized. Static folder: {FLASK_STATIC_FOLDER_PATH}, Static URL path: /static, Template folder: {FLASK_APP_TEMPLATE_FOLDER_PATH}")
 
 # Secret Key (ensure this is strong and unique in production)
 app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'your-default-secret-key-change-me')

--- a/backend/cover_letter_app/__init__.py
+++ b/backend/cover_letter_app/__init__.py
@@ -3,16 +3,16 @@ from flask import Blueprint
 
 # Define paths relative to this file's location (backend/cover_letter_app/__init__.py)
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
-TEMPLATE_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'templates', 'cover_letter')
+# TEMPLATE_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'templates', 'cover_letter') # No longer needed here
 STATIC_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'static')
 
-# Templates are in frontend/templates/cover_letter
+# Template folder is now handled by the app.
 # Static folder can remain general if not specifically used by this blueprint,
 # or can be set to a specific static folder for this blueprint if needed.
 cover_letter_bp = Blueprint(
     'cover_letter',
     __name__,
-    template_folder=TEMPLATE_FOLDER, # Corrected path
+    # template_folder=TEMPLATE_FOLDER, # Removed
     static_folder=STATIC_FOLDER # General static folder, adjust if needed
 )
 

--- a/backend/mock_interview_app/__init__.py
+++ b/backend/mock_interview_app/__init__.py
@@ -3,12 +3,12 @@ from flask import Blueprint
 
 # Define paths relative to this file's location (backend/mock_interview_app/__init__.py)
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
-TEMPLATE_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'templates', 'mock_interview')
+# TEMPLATE_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'templates', 'mock_interview') # No longer needed here
 STATIC_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'static')
 
 mock_interview_bp = Blueprint('mock_interview',
                               __name__,
-                              template_folder=TEMPLATE_FOLDER,
+                              # template_folder=TEMPLATE_FOLDER, # Removed
                               static_folder=STATIC_FOLDER)
 
 from . import routes

--- a/backend/resume_builder/__init__.py
+++ b/backend/resume_builder/__init__.py
@@ -1,19 +1,21 @@
 import os # Added for path manipulation
 from flask import Blueprint
 
+import os # Added for path manipulation
+from flask import Blueprint
+
 # Define paths relative to this file's location (backend/resume_builder/__init__.py)
 # os.path.dirname(__file__) is backend/resume_builder/
 # os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')) is project_root/ (e.g., src/)
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
-TEMPLATE_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'templates', 'resume_builder')
-STATIC_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'static')
+# TEMPLATE_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'templates', 'resume_builder') # No longer needed here
+STATIC_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'static') # General static, or specific if needed
 
 
-# Define the blueprint. Adjust template_folder if necessary.
-# Assuming resume_builder templates are in 'frontend/templates/resume_builder/'
+# Define the blueprint. Template folder is now handled by the app.
 bp = Blueprint('resume_builder',
                __name__,
-               template_folder=TEMPLATE_FOLDER,
+               # template_folder=TEMPLATE_FOLDER, # Removed
                static_folder=STATIC_FOLDER, # If it has specific static files
                static_url_path='/resume-builder/static') # URL path for its static files
 

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -13,10 +13,10 @@ logger = logging.getLogger(__name__) # Added for logging
 # Define paths relative to this file's location (backend/routes.py)
 # os.path.dirname(__file__) is backend/
 # os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) is project_root/ (e.g., src/)
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-MAIN_TEMPLATE_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'templates')
+# PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # No longer needed for template folder here
+# MAIN_TEMPLATE_FOLDER = os.path.join(PROJECT_ROOT, 'frontend', 'templates') # No longer needed here
 
-main_bp = Blueprint('main', __name__, template_folder=MAIN_TEMPLATE_FOLDER)
+main_bp = Blueprint('main', __name__) # Removed template_folder argument
 
 @main_bp.route('/')
 def home():


### PR DESCRIPTION
- Set a global `template_folder` in `backend/app.py` to point to `frontend/templates/` for the main Flask application.
- Removed specific `template_folder` arguments from all blueprint initializations (main_bp, resume_builder_bp, cover_letter_bp, mock_interview_bp).
- This ensures all `render_template()` calls resolve paths relative to the global `frontend/templates/` directory, simplifying template lookup and addressing potential misconfigurations that led to blank pages.